### PR TITLE
Update for LSPDFR 0.4

### DIFF
--- a/Stealth.Common/Extensions/StringExtensions.cs
+++ b/Stealth.Common/Extensions/StringExtensions.cs
@@ -52,7 +52,7 @@ namespace Stealth.Common.Extensions
                 FormattedText formatted = new FormattedText(item,
                      CultureInfo.GetCultureInfo("en-us"),
                      System.Windows.FlowDirection.LeftToRight,
-                     new Typeface(fontFamily), emSize, System.Windows.Media.Brushes.Black);
+                     new Typeface(fontFamily), emSize, System.Windows.Media.Brushes.Black, pixels);
 
                 actualLine.Append(item + " ");
                 actualWidth += formatted.Width;

--- a/Stealth.Common/Properties/AssemblyInfo.cs
+++ b/Stealth.Common/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Stealth22")]
 [assembly: AssemblyProduct("Stealth.Common")]
-[assembly: AssemblyCopyright("Copyright © 2018 Stealth22")]
+[assembly: AssemblyCopyright("Copyright © 2019 Stealth22")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Stealth.Common/Stealth.Common.csproj
+++ b/Stealth.Common/Stealth.Common.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Stealth.Common</RootNamespace>
     <AssemblyName>Stealth.Common</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>


### PR DESCRIPTION
- Updated .NET framework to 4.7.2
- Added pixels to FormattedText init in StringExtensions.cs. .NET 4.7.2 shows an obsolete warning if this param is not given
- Updated Copyright to current year

CROSS UPDATE WITH CODE 3 CALLOUTS